### PR TITLE
cssBayan

### DIFF
--- a/cssBayan/index.html
+++ b/cssBayan/index.html
@@ -9,7 +9,7 @@
         integrity="sha512-SzlrxWUlpfuzQ+pcUCosxcglQRNAq/DZjVsC0lE40xsADsfeQoEypE+enwcOiGjk/bSuGGKHEyjSoQ1zVisanQ=="
         crossorigin="anonymous" referrerpolicy="no-referrer" />
         <!-- ссылка на иконки -->
-    <link href="/cssBayan/style.css" rel="stylesheet">
+    <link href="./style.css" rel="stylesheet">
 </head>
 <body>
     <div class="accordion-cont">
@@ -29,7 +29,7 @@
                         <!-- помещено в lable для того чтобы было можно обрашать к тексту и картини, через div не работало -->
                     </div>
                     <label for="mem-1" class="accardion-img">
-                        <img src="/cssBayan/img/mem1.jpg">
+                        <img src="./img/mem1.jpg">
                     </label>
                     <!-- здесь также -->
                 </li>
@@ -43,7 +43,7 @@
                         </label>
                     </div>
                     <label for="mem-2" class="accardion-img">
-                        <img src="/cssBayan/img/mem2.jpg">
+                        <img src="./img/mem2.jpg">
                     </label>
                 </li>
 
@@ -56,7 +56,7 @@
                         </label>
                     </div>
                     <label for="mem-3" class="accardion-img">
-                        <img src="/cssBayan/img/mem3.jpg">
+                        <img src="./img/mem3.jpg">
                     </label>
                 </li>
 
@@ -69,7 +69,7 @@
                         </label>
                     </div>
                     <label for="mem-4" class="accardion-img">
-                        <img src="/cssBayan/img/mem4.png">
+                        <img src="./img/mem4.png">
                     </label>
                 </li>
 
@@ -82,24 +82,26 @@
                         </label>
                     </div>
                     <label for="mem-5" class="accardion-img">
-                        <img src="/cssBayan/img/mem5.jpg">
+                        <img src="./img/mem5.jpg">
                     </label>
                 </li>
             </ul>
+`
             <div class="button">
                 <button> <a href="https://ok.ru/">MEMS WAS FUN</a></button>
                 <button><a href="https://youtu.be/VM7XaWgZ_b8">ITS BULL SHIT</a></button>
             </div>
+
             <div class="easter-block">
             <input type="radio" class="input" id="easter" />
             <label for="easter">
                 <h2>Create by A4A4UK</h2>
             </label>
             <div class="cont-ea">
-                <p class="heart">R U HAPPY?</p>   
+                <p class="heart">DO U HAVE CANCER?</p>   
             <label for="easter" class="ea">
-                <button class="n"><a href="https://youtu.be/GxBj59uutZM">Yes</a></button> 
-                <button class="n"><a href="https://youtu.be/0hfOyOBHIq4">!Im FINE</a></button>
+                <button class="n"><a href="https://youtu.be/34Rp6KVGIEM">Yes</a></button> 
+                <button class="n"><a href="https://jut.su/stein-gate">No</a></button>
             </label>
             </div>
             </div>

--- a/cssBayan/style.css
+++ b/cssBayan/style.css
@@ -43,15 +43,15 @@ input{
 
 
 .accordion-element-box:hover ~ .accardion-img img{
-    width: 40%;
+    width: 42%;
     height: 40%;
 }
 .accardion-img:hover img{
-    width: 40%;
+    width: 42%;
     height: 40%;
 }
 .accordion-element-block:has(input[type=radio]:checked) img {
-    width: 40%;
+    width: 42%;
     height: 40%;
 }
 .accordion-element-block:hover i {


### PR DESCRIPTION
1 https://github.com/DrDiman/CSS-Bayan-task
2 screenshot: ![wq](https://user-images.githubusercontent.com/127003716/224704316-2b264336-8bd4-4d60-bdc7-98ef573f77fd.png)
3 https://a4u4uk.github.io/cssBayan/cssBayan/
4 Done 12.03.23 deadline 13.03.23
5 Score: 120 / 140
1 verything is done from Repository requirements and how to submit task section 25/30
2 The accordion component is centered on the screen, with equal indents on the left and right 10/10
3 Icons, meme texts and meme images are exist 5/5
4 Placement of the meme, icons and meme text are the same as in provided example gif images 5/5
5 Smooth change (transition) of the meme images and icons is done 20/20
6 Responsive design with three breakpoints for mobile, tablet, and desktop exist. Accordion is displayed correctly at mobile 320x568, tablet 820x1180, desktop 1920×1080. (Note: breakpoints don't have to be 320x568, 820x1180, 1920x1080). 0/10
7 All visual effects when the cursor is hovering over the memes, when the mouse is down on a meme, and when a meme is selected are implemented 10/10
8 The entire row (text, icon, and meme image) clickable 5/5
9 Cursor over the memes (hover) effect only exists for devices that can support hover. 10/10
10 The cursor when it is hovering over the rows of the accordion is changing 5/5
11 Only flexible dimensions are used rem, em, %, vh, vw, fr and etc... The accordion is responsive 10/10
12 All blocks/parts of the accordion are in base flow of the dom elements. All elements are not positioned with top, left, right, bottom. float is not used. The value of position is only static 5/5
13 Pseudo-elements are not used (note 1: pseudo-classes are allowed; note 2: pseudo-elements only from FontAwesome are allowed) 5/5
14 Initially, the first meme should be expanded 5/5
15 Font size is changed at each device (mobile, tablet, desktop) 0/5